### PR TITLE
feature: binance markPrice 增加速度选项

### DIFF
--- a/uxapi/exchanges/binance.py
+++ b/uxapi/exchanges/binance.py
@@ -57,7 +57,7 @@ class Binance(UXPatch, ccxt.binance):
                     'orderbook': '{symbol}@depth{level}',
                     'ohlcv': '{symbol}@kline_{period}',
                     'aggTrade': '{symbol}@aggTrade',
-                    'markPrice': '{symbol}@markPrice',
+                    'markPrice': '{symbol}@markPrice{speed}',
                     'miniTicker': '{symbol}@miniTicker',
                     'ticker': '{symbol}@ticker',
                     'quote': '{symbol}@bookTicker',
@@ -131,6 +131,14 @@ class Binance(UXPatch, ccxt.binance):
         elif maintype == 'ohlcv':
             period = self.timeframes[subtypes[0]]
             return template.format(symbol=symbol, period=period)
+        elif maintype == 'markPrice':
+            if not subtypes:
+                speed = ''
+            elif subtypes[0] == '1s':
+                speed = '@1s'
+            else:
+                speed = ''
+            return template.format(symbol=symbol, speed=speed)
         else:
             return template.format(symbol=symbol)
 


### PR DESCRIPTION
https://binance-docs.github.io/apidocs/futures/en/#mark-price-stream

币安的 markPrice 增加了一个 1s 推送速度的选项